### PR TITLE
feat: allow Markdown ↔ JIRA conversion from untitled editors

### DIFF
--- a/src/convertUtils.ts
+++ b/src/convertUtils.ts
@@ -1,13 +1,59 @@
 import jira2md from 'jira2md';
 import * as vscode from 'vscode';
 import { createNewDocument } from './documentUtils';
-import { getDirectoryPath, getFileExtension } from './fileUtils';
+import { type DocumentFormat, detectDocumentFormat } from './formatUtils';
+import { getOutputDirectory, isConvertibleDocument } from './fileUtils';
 
 type ConversionOptions = {
   sourceExtension: string;
   targetExtension: string;
   convertFunction: (text: string) => string;
   errorMessage: string;
+};
+
+type ResolvedConversion = {
+  targetExtension: string;
+  convertFunction: (text: string) => string;
+};
+
+const getConversionForFormat = (format: DocumentFormat): ResolvedConversion => {
+  if (format === 'markdown') {
+    return {
+      targetExtension: '.jira',
+      convertFunction: jira2md.to_jira,
+    };
+  }
+
+  return {
+    targetExtension: '.md',
+    convertFunction: jira2md.to_markdown,
+  };
+};
+
+const promptDocumentFormat = async (): Promise<DocumentFormat | undefined> => {
+  const selection = await vscode.window.showQuickPick(
+    [
+      { label: 'Markdown', value: 'markdown' as const },
+      { label: 'JIRA', value: 'jira' as const },
+    ],
+    { placeHolder: 'Select the format of the current untitled document' },
+  );
+
+  return selection?.value;
+};
+
+const resolveUntitledConversion = async (document: vscode.TextDocument): Promise<ResolvedConversion | undefined> => {
+  let format = detectDocumentFormat(document.getText(), document.languageId);
+
+  if (format === 'unknown') {
+    format = await promptDocumentFormat() ?? 'unknown';
+  }
+
+  if (format === 'unknown') {
+    return undefined;
+  }
+
+  return getConversionForFormat(format);
 };
 
 const convertDocument = async (options: ConversionOptions): Promise<void> => {
@@ -18,18 +64,24 @@ const convertDocument = async (options: ConversionOptions): Promise<void> => {
   }
 
   const document = editor.document;
-  const fileExtension = getFileExtension(document);
+  const conversion = document.isUntitled
+    ? await resolveUntitledConversion(document)
+    : isConvertibleDocument(document, options.sourceExtension)
+      ? { targetExtension: options.targetExtension, convertFunction: options.convertFunction }
+      : undefined;
 
-  if (fileExtension !== options.sourceExtension) {
-    vscode.window.showInformationMessage(options.errorMessage);
+  if (!conversion) {
+    if (!document.isUntitled) {
+      vscode.window.showInformationMessage(options.errorMessage);
+    }
     return;
   }
 
-  const formattedText = options.convertFunction(document.getText());
+  const formattedText = conversion.convertFunction(document.getText());
   await createNewDocument(
-    getDirectoryPath(document),
+    getOutputDirectory(document),
     formattedText,
-    options.targetExtension
+    conversion.targetExtension
   );
 };
 

--- a/src/documentUtils.ts
+++ b/src/documentUtils.ts
@@ -1,9 +1,14 @@
 import path from 'node:path';
 import * as vscode from 'vscode';
 
-export const createNewDocument = async (directory: string, content: string, fileExtension: string): Promise<void> => {
-  const newFilePath = path.join(directory, `formatted_file${fileExtension}`);
-  const uri = vscode.Uri.file(newFilePath).with({ scheme: 'untitled' });
+export const createNewDocument = async (
+  directory: string | undefined,
+  content: string,
+  fileExtension: string,
+): Promise<void> => {
+  const uri = directory
+    ? vscode.Uri.file(path.join(directory, `formatted_file${fileExtension}`)).with({ scheme: 'untitled' })
+    : vscode.Uri.parse(`untitled:formatted_file${fileExtension}`);
 
   const document = await vscode.workspace.openTextDocument(uri);
   const edit = new vscode.WorkspaceEdit();

--- a/src/fileUtils.ts
+++ b/src/fileUtils.ts
@@ -3,4 +3,15 @@ import type * as vscode from 'vscode';
 
 export const getFileExtension = (document: vscode.TextDocument): string => path.extname(document.fileName);
 
-export const getDirectoryPath = (document: vscode.TextDocument): string => path.dirname(document.uri.path);
+export const isConvertibleDocument = (
+  document: vscode.TextDocument,
+  sourceExtension: string,
+): boolean => document.isUntitled || getFileExtension(document) === sourceExtension;
+
+export const getOutputDirectory = (document: vscode.TextDocument): string | undefined => {
+  if (document.isUntitled) {
+    return undefined;
+  }
+
+  return path.dirname(document.uri.fsPath);
+};

--- a/src/formatUtils.ts
+++ b/src/formatUtils.ts
@@ -1,0 +1,42 @@
+export type DocumentFormat = 'markdown' | 'jira' | 'unknown';
+
+const JIRA_PATTERNS: RegExp[] = [
+  /\{code[:|\s]/,
+  /\{noformat\}/,
+  /\{quote\}/,
+  /^h[1-6]\.\s/m,
+  /\{color:[^}]+\}/,
+  /\|\|[^|\n]+\|\|/,
+];
+
+const MARKDOWN_PATTERNS: RegExp[] = [
+  /```[\s\S]*?```/,
+  /~~~[\s\S]*?~~~/,
+  /^#{2,6}\s/m,
+  /\[[^\]]+\]\([^)]+\)/,
+  /!\[[^\]]*\]\([^)]+\)/,
+  /^\s*[-*+]\s+\S/m,
+];
+
+const scorePatterns = (text: string, patterns: RegExp[]): number => {
+  return patterns.reduce((score, pattern) => score + (pattern.test(text) ? 1 : 0), 0);
+};
+
+export const detectDocumentFormat = (text: string, languageId?: string): DocumentFormat => {
+  if (languageId === 'markdown') {
+    return 'markdown';
+  }
+
+  const jiraScore = scorePatterns(text, JIRA_PATTERNS);
+  const markdownScore = scorePatterns(text, MARKDOWN_PATTERNS);
+
+  if (jiraScore > markdownScore) {
+    return 'jira';
+  }
+
+  if (markdownScore > jiraScore) {
+    return 'markdown';
+  }
+
+  return 'unknown';
+};

--- a/src/test/fileUtils.test.ts
+++ b/src/test/fileUtils.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'node:assert';
+import type * as vscode from 'vscode';
+import { getOutputDirectory, isConvertibleDocument } from '../fileUtils';
+
+const createDocument = (overrides: Partial<vscode.TextDocument>): vscode.TextDocument => {
+  return {
+    fileName: 'example.md',
+    isUntitled: false,
+    uri: { fsPath: String.raw`C:\project\example.md` } as vscode.Uri,
+    ...overrides,
+  } as vscode.TextDocument;
+};
+
+suite('fileUtils', () => {
+  suite('isConvertibleDocument', () => {
+    test('allows matching file extensions', () => {
+      const document = createDocument({ fileName: 'notes.md' });
+
+      assert.strictEqual(isConvertibleDocument(document, '.md'), true);
+      assert.strictEqual(isConvertibleDocument(document, '.jira'), false);
+    });
+
+    test('allows untitled editors regardless of file name', () => {
+      const document = createDocument({
+        fileName: 'Untitled-1',
+        isUntitled: true,
+        uri: { fsPath: '' } as vscode.Uri,
+      });
+
+      assert.strictEqual(isConvertibleDocument(document, '.md'), true);
+      assert.strictEqual(isConvertibleDocument(document, '.jira'), true);
+    });
+  });
+
+  suite('getOutputDirectory', () => {
+    test('returns the source directory for saved files', () => {
+      const document = createDocument({
+        uri: { fsPath: String.raw`C:\project\notes.md` } as vscode.Uri,
+      });
+
+      assert.strictEqual(getOutputDirectory(document), String.raw`C:\project`);
+    });
+
+    test('returns undefined for untitled editors', () => {
+      const document = createDocument({
+        fileName: 'Untitled-1',
+        isUntitled: true,
+        uri: { fsPath: '' } as vscode.Uri,
+      });
+
+      assert.strictEqual(getOutputDirectory(document), undefined);
+    });
+  });
+});

--- a/src/test/formatUtils.test.ts
+++ b/src/test/formatUtils.test.ts
@@ -1,0 +1,33 @@
+import * as assert from 'node:assert';
+import { detectDocumentFormat } from '../formatUtils';
+
+const jiraSample = `# *Run the hobby deployment script:*
+
+   {code:bash}
+   curl -fsSL https://raw.githubusercontent.com/some-arbitrary-url/bash.sh
+   {code} (please ignore the extra escape so it won't break)`;
+
+const markdownSample = `# Run the hobby deployment script
+
+\`\`\`bash
+curl -fsSL https://raw.githubusercontent.com/some-arbitrary-url/bash.sh
+\`\`\` (please ignore the extra escape so it won't break)`;
+
+suite('formatUtils', () => {
+  suite('detectDocumentFormat', () => {
+    test('detects JIRA markup in untitled content', () => {
+      assert.strictEqual(detectDocumentFormat(jiraSample), 'jira');
+    });
+
+    test('detects Markdown in untitled content', () => {
+      assert.strictEqual(detectDocumentFormat(markdownSample), 'markdown');
+    });
+
+    test('uses languageId as a hint when patterns are ambiguous', () => {
+      const ambiguous = 'Run the hobby deployment script';
+
+      assert.strictEqual(detectDocumentFormat(ambiguous, 'markdown'), 'markdown');
+      assert.strictEqual(detectDocumentFormat(ambiguous), 'unknown');
+    });
+  });
+});


### PR DESCRIPTION
Skip file-extension checks for untitled documents and open converted output in a new untitled tab when the source editor is unsaved.

Closes #3